### PR TITLE
Dataform dfe qts analytics

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -5,6 +5,7 @@ dfeAnalyticsDataform({
   bqProjectName: "apply-for-qts-in-england",
   bqDatasetName: "events_production",
   bqEventsTableName: "events",
+  urlRegex: "www.apply-for-qts-in-england.education.gov.uk",
   dataSchema: [{
     entityTableName: "active_storage_variant_records",
     description: "",

--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -5,7 +5,7 @@ dfeAnalyticsDataform({
   bqProjectName: "apply-for-qts-in-england",
   bqDatasetName: "events_production",
   bqEventsTableName: "events",
-  urlRegex: "www.apply-for-qts-in-england.education.gov.uk",
+  urlRegex: "apply-for-qts-in-england.education.gov.uk",
   dataSchema: [{
     entityTableName: "active_storage_variant_records",
     description: "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,8 +79,8 @@
             "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "dfe-analytics-dataform": {
-            "version": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#4a7781799690461dd8a0154ac6d4438cee512be9",
-            "from": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.10.1",
+            "version": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#272c6dfef41c75a883ad2236b98a911f5c81453b",
+            "from": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.0",
             "requires": {
                 "@dataform/core": "1.22.1"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "1.22.2",
-        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.10.1"
+        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.0"
     }
 }


### PR DESCRIPTION
Updated 1-2 below. For the other action (4-5), can we do this together once you have merged?

**Update instructions
This release changes the clustering on the pageview_with_funnels table. BigQuery does not permit this along with an update to an existing table. This release also introduces a new urlRegex configuration parameter, which is mandatory. Please follow the instructions below to update instead of the usual process.**
1. In Dataform, update the version of dfe-analytics-dataform in your package.json file to v1.0.0.
2. In Dataform, add the new urlRegex parameter to the list of parameters passed to dfe-analytics-dataform() in your dfe_analytics_dataform.js file. This is a regular expression for dfe-analytics-dataform to use to identify whether a URL is this service's own URL or an external one. If your service only has one domain name set this to 'www.yourdomainname.gov.uk' (without the protocol). If you have more than one use something like '(?i)(www.domain1.gov.uk|www.domain2.gov.uk|www.domain3.gov.uk)'.
3. Merge your changes to main/master
4. In BigQuery, delete the pageview_with_funnels_{eventSourceName} table from your dataform dataset.
5. In Dataform, run a full refresh on the pageview_with_funnels_{eventSourceName} table.
6. In Dataform, run the query to generate the sessions_{eventSourceName} table (no full refresh required).