### PR TITLE
Dataform dfe qts analytics

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -430,43 +430,7 @@ dfeAnalyticsDataform({
       dataType: "string",
       description: "",
     }]
-  }, {
-    entityTableName: "timeline_events",
-    description: "",
-    keys: [{
-      keyName: "event_type",
-      dataType: "string",
-      description: "",
-      alias: "qts_event_type"
-    }, {
-      keyName: "application_form_id",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "annotation",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "creator_id",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "creator_type",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "assignee_id",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "old_state",
-      dataType: "string",
-      description: "",
-    }, {
-      keyName: "new_state",
-      dataType: "string",
-      description: "",
-    }]
+  
   }, {
     entityTableName: "uploads",
     description: "",
@@ -628,6 +592,54 @@ dfeAnalyticsDataform({
       description: "",
     }, {
       keyName: "failure_reason_key",
+      dataType: "string",
+      description: "",
+    }]
+  }, {
+    entityTableName: "timeline_events",
+    description: "",
+    keys: [{
+      keyName: "application_form_id",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "annotation",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "creator_id",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "creator_type",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "assignee_id",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "old_state",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "new_state",
+      dataType: "string",
+      description: "",
+    }]
+  }, {
+    entityTableName: "assessment_section_failure_reasons",
+    description: "",
+    keys: [{
+      keyName: "assessment_section_id",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "key",
+      dataType: "string",
+      description: "",
+    }, {
+      keyName: "assessor_feedback",
       dataType: "string",
       description: "",
     }]

--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -430,7 +430,6 @@ dfeAnalyticsDataform({
       dataType: "string",
       description: "",
     }]
-  
   }, {
     entityTableName: "uploads",
     description: "",

--- a/definitions/joinGeoData.sqlx
+++ b/definitions/joinGeoData.sqlx
@@ -29,10 +29,13 @@ except(
     status_check,
     legacy,
     string_field_0,
-    string_field_1
+    string_field_1,
+    string_field_2
   ),
   tableA.id AS region_id,
-  string_field_1 AS country_name
+  string_field_1 AS country_name,
+  string_field_2 AS country_route
+
 FROM
   ${ref("regions_latest_apply-for-qts")} AS tableA
   INNER JOIN ${ref("countries_latest_apply-for-qts")} AS tableB ON tableA.country_id = tableB.id


### PR DESCRIPTION
added assessment_section_failure_reasons to dataform https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/db/schema.rb#L97 

removed event_type from timeline events - couldn't think of any other way to solve the error