### PR TITLE
Inclusion of professional standing expired_at in Application Forms custom query

### DIFF
--- a/definitions/Applications_CustomQuery.sqlx
+++ b/definitions/Applications_CustomQuery.sqlx
@@ -14,8 +14,21 @@ SELECT
     last_streamed_event_type,
     updated_at,
     state,
+    assessment_id,
+    expired_at,
+    location_note,
+    ready_for_review,
+    verified_at,
+    verify_note,
+    verify_passed,
+    review_note,
+    received_at,
+    requested_at,
+    reviewed_at,
     age_range_min,
     age_range_max ),
+  assessments.id AS assessment_id,
+  professional_standing.expired_at AS ps_expired_at,
   application_forms.id AS id,
   application_forms.created_at AS created_at,
   application_forms.state AS state,
@@ -26,6 +39,11 @@ SELECT
   assessments.updated_at AS assessment_updated_at,
   further_information_requests.state AS FI_state,
   further_information_requests.created_at AS further_information_requests_created_at,
+  further_information_requests.expired_at AS expired_at,
+  further_information_requests.review_note AS review_note,
+  further_information_requests.received_at AS received_at,
+  further_information_requests.requested_at AS requested_at,
+  further_information_requests.reviewed_at AS reviewed_at,
   assessments.subjects AS subjects,
   ABS(TIME_DIFF(EXTRACT(TIME
       FROM
@@ -47,17 +65,7 @@ SELECT
       FROM
         further_information_requests.created_at), EXTRACT(TIME
       FROM
-        started_at), MINUTE)) AS minutes_since_started_to_FIed,
-        professional_standing.expired_at as professional_standing_expired_at,
-     professional_standing.expired_at as professional_standing_expired_at,
-     professional_standing.received_at as professional_standing_received_at,
-     professional_standing.assessment_id as professional_standing_assessment_id,
-     professional_standing.review_note as professional_standing_review_note,
-     professional_standing.requested_at as professional_standing_requested_at,
-  professional_standing.reviewed_at as professional_standing_reviewed_at
- 
-
-
+        started_at), MINUTE)) AS minutes_since_started_to_FIed
 FROM
   ${ref("application_forms_latest_afqts")} AS application_forms
 LEFT JOIN

--- a/definitions/Applications_CustomQuery.sqlx
+++ b/definitions/Applications_CustomQuery.sqlx
@@ -25,6 +25,7 @@ SELECT
     received_at,
     requested_at,
     reviewed_at,
+    review_passed,
     age_range_min,
     age_range_max ),
   assessments.id AS assessment_id,
@@ -44,6 +45,7 @@ SELECT
   further_information_requests.received_at AS received_at,
   further_information_requests.requested_at AS requested_at,
   further_information_requests.reviewed_at AS reviewed_at,
+  further_information_requests.review_passed AS review_passed,
   assessments.subjects AS subjects,
   ABS(TIME_DIFF(EXTRACT(TIME
       FROM

--- a/definitions/Applications_CustomQuery.sqlx
+++ b/definitions/Applications_CustomQuery.sqlx
@@ -48,7 +48,16 @@ SELECT
         further_information_requests.created_at), EXTRACT(TIME
       FROM
         started_at), MINUTE)) AS minutes_since_started_to_FIed,
-        professional_standing.expired_at as professional_standing_expired_at
+        professional_standing.expired_at as professional_standing_expired_at,
+     professional_standing.expired_at as professional_standing_expired_at,
+     professional_standing.received_at as professional_standing_received_at,
+     professional_standing.assessment_id as professional_standing_assessment_id,
+     professional_standing.review_note as professional_standing_review_note,
+     professional_standing.requested_at as professional_standing_requested_at,
+  professional_standing.reviewed_at as professional_standing_reviewed_at
+ 
+
+
 FROM
   ${ref("application_forms_latest_afqts")} AS application_forms
 LEFT JOIN

--- a/definitions/Applications_CustomQuery.sqlx
+++ b/definitions/Applications_CustomQuery.sqlx
@@ -1,15 +1,12 @@
 config {
-  type: "table",
- /* assertions: {
-    uniqueKey: ["id"],
-  },*/
+    type: "table",
+    /* assertions: {
+       uniqueKey: ["id"],
+     },*/
 }
 
 SELECT
-  *
-EXCEPT
-  (
-    id,
+  * EXCEPT ( id,
     created_at,
     region_id,
     subjects,
@@ -18,27 +15,55 @@ EXCEPT
     updated_at,
     state,
     age_range_min,
-    age_range_max
-  ),
-  tableA.id AS id,
-  tableA.created_at AS created_at,
-  tableA.state AS state,
-  tableC.id AS assessment_latest_id,
-  tableC.created_at AS assessment_created_at,
-  tableA.region_id AS region_id,
-  tableA.updated_at AS updated_at,
-  tableC.updated_at AS assessment_updated_at,
-  tableD.state AS FI_state,
-  tableD.created_at AS further_information_requests_created_at,
-  tableC.subjects AS subjects,
-  ABS(TIME_DIFF(EXTRACT(TIME FROM started_at), EXTRACT(TIME FROM recommended_at), MINUTE)) as minutes_started_to_recommended,
-  ABS(TIME_DIFF(EXTRACT(TIME FROM started_at), CURRENT_TIME(),  MINUTE)) as minutes_since_started,
-  ABS(TIME_DIFF(EXTRACT(TIME FROM received_at), EXTRACT(TIME FROM recommended_at), MINUTE)) as minutes_received_to_recommended,
-  ABS(TIME_DIFF(EXTRACT(TIME FROM received_at), CURRENT_TIME(),  MINUTE)) as minutes_since_received,
-  ABS(TIME_DIFF(EXTRACT(TIME FROM tableD.created_at), EXTRACT(TIME FROM started_at),  MINUTE)) as minutes_since_started_to_FIed,
+    age_range_max ),
+  application_forms.id AS id,
+  application_forms.created_at AS created_at,
+  application_forms.state AS state,
+  assessments.id AS assessment_latest_id,
+  assessments.created_at AS assessment_created_at,
+  application_forms.region_id AS region_id,
+  application_forms.updated_at AS updated_at,
+  assessments.updated_at AS assessment_updated_at,
+  further_information_requests.state AS FI_state,
+  further_information_requests.created_at AS further_information_requests_created_at,
+  assessments.subjects AS subjects,
+  ABS(TIME_DIFF(EXTRACT(TIME
+      FROM
+        started_at), EXTRACT(TIME
+      FROM
+        recommended_at), MINUTE)) AS minutes_started_to_recommended,
+  ABS(TIME_DIFF(EXTRACT(TIME
+      FROM
+        started_at), CURRENT_TIME(), MINUTE)) AS minutes_since_started,
+  ABS(TIME_DIFF(EXTRACT(TIME
+      FROM
+        further_information_requests.received_at), EXTRACT(TIME
+      FROM
+        recommended_at), MINUTE)) AS minutes_received_to_recommended,
+  ABS(TIME_DIFF(EXTRACT(TIME
+      FROM
+        further_information_requests.received_at), CURRENT_TIME(), MINUTE)) AS minutes_since_received,
+  ABS(TIME_DIFF(EXTRACT(TIME
+      FROM
+        further_information_requests.created_at), EXTRACT(TIME
+      FROM
+        started_at), MINUTE)) AS minutes_since_started_to_FIed,
+        professional_standing.expired_at as professional_standing_expired_at
 FROM
-  ${ref("application_forms_latest_afqts")} AS tableA
-  LEFT JOIN ${ref("joinGeoData")} AS tableB ON tableA.region_id = tableB.region_id
-  LEFT JOIN ${ref("assessments_latest_afqts")} AS tableC ON tableA.id = tableC.application_form_id
-  LEFT JOIN ${ref("further_information_requests_latest_afqts")} AS tableD ON tableC.id = tableD.assessment_id
-
+  ${ref("application_forms_latest_afqts")} AS application_forms
+LEFT JOIN
+  ${ref("joinGeoData")} AS joinGeoData
+ON
+  application_forms.region_id = joinGeoData.region_id
+LEFT JOIN
+  ${ref("assessments_latest_afqts")} AS assessments
+ON
+  application_forms.id = assessments.application_form_id
+LEFT JOIN
+  ${ref("further_information_requests_latest_afqts")} AS further_information_requests
+ON
+  assessments.id = further_information_requests.assessment_id
+LEFT JOIN
+  ${ref("professional_standing_requests_latest_afqts")} AS professional_standing
+ON
+  professional_standing.assessment_id = assessments.id


### PR DESCRIPTION
Quite a few code lines to work around the duplicate fields  between further information and professional standing tables. For now i have prefixed a ps on the professional standing and left the further information fields in their original state so i dont break the dashboard.