### PR TITLE
Ap dev

### DIFF
--- a/definitions/assessor_workload_per_day.sqlx
+++ b/definitions/assessor_workload_per_day.sqlx
@@ -11,24 +11,24 @@ WITH
   SELECT
     entity_id,
     key_updated,
-    new_assessor_id,
-    previous_action_required_by,
-    new_action_required_by,
+    assessor_id,
+    previous_value as previous_action_required_by,
+    new_value as new_action_required_by,
     occurred_at
   FROM
  ${ref("application_forms_field_updates_afqts")} AS application_forms_field_updates
   WHERE
     key_updated IN ('action_required_by')
-    AND previous_action_required_by = 'assessor'
-    AND new_action_required_by != 'assessor' ),
+    AND previous_value = 'assessor'
+    AND new_value != 'assessor' ),
   -- rank and select the latest record for an application
   ranked_records_assessor_change AS (
 SELECT
   entity_id,
   key_updated,
-  previous_action_required_by,
-  new_action_required_by,
-  new_assessor_id,
+   previous_action_required_by,
+   new_action_required_by,
+  assessor_id,
   occurred_at,
   ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY occurred_at DESC) AS rn
 FROM
@@ -37,9 +37,9 @@ FROM
   SELECT
     entity_id,
     key_updated,
-    new_assessor_id,
-    previous_action_required_by,
-    new_action_required_by,
+    assessor_id,
+   previous_action_required_by,
+  new_action_required_by,
     DATE(occurred_at) AS date_actioned_at
   FROM
     ranked_records_assessor_change
@@ -50,8 +50,8 @@ FROM
 SELECT
   date_actioned_at,
   count (*) AS count_of_assessments_by_action_required,
-  COUNT(DISTINCT new_assessor_id) AS count_of_assessors_by_action_required,
-  CAST(ROUND(COUNT(*) / COUNT(DISTINCT new_assessor_id),0) AS INT64) AS average_assessments_per_assessor_by_action_required
+  COUNT(DISTINCT assessor_id) AS count_of_assessors_by_action_required,
+  CAST(ROUND(COUNT(*) / COUNT(DISTINCT assessor_id),0) AS INT64) AS average_assessments_per_assessor_by_action_required
 FROM
   latest_assessor_change
 GROUP BY

--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1749,6 +1749,7 @@ dfeAnalyticsDataform({
                     keyName: "new_value",
                     dataType: "string",
                     description: "",
+                     alias: "new_event_value",
                 },
                 {
                     keyName: "note_id",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@dataform/core": "2.6.7",
-                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.7.3.tar.gz"
+                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.0.tar.gz"
             }
         },
         "node_modules/@dataform/core": {
@@ -81,8 +81,8 @@
             "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
         },
         "node_modules/dfe-analytics-dataform": {
-            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.7.3.tar.gz",
-            "integrity": "sha512-GnlMkzxrKJy1c7oIOJQvIN63ec4CgX45SXgBnbvHcVXsdyCxJbwcMoAdHa+tE7c90P98Xry9l5Oai5Gn2E0eKA==",
+            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.0.tar.gz",
+            "integrity": "sha512-oVyZmWiik525oEdxWp1SctxoSizW3NOIPRqrhx94dNHrelWJYGW8bZH+oUHQMXB40SvJJ/O5kLLiBoECfJ3CfA==",
             "dependencies": {
                 "@dataform/core": "2.7.0"
             }
@@ -246,8 +246,8 @@
             "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
         },
         "dfe-analytics-dataform": {
-            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.7.3.tar.gz",
-            "integrity": "sha512-GnlMkzxrKJy1c7oIOJQvIN63ec4CgX45SXgBnbvHcVXsdyCxJbwcMoAdHa+tE7c90P98Xry9l5Oai5Gn2E0eKA==",
+            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.0.tar.gz",
+            "integrity": "sha512-oVyZmWiik525oEdxWp1SctxoSizW3NOIPRqrhx94dNHrelWJYGW8bZH+oUHQMXB40SvJJ/O5kLLiBoECfJ3CfA==",
             "requires": {
                 "@dataform/core": "2.7.0"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "2.6.7",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.7.3.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.0.tar.gz"
     }
 }


### PR DESCRIPTION
Hi Thomas, this is i think the last change needed for 1.8.0. There were 2 assertion failures due to the new field updates table structure changes, fixed now.

assessor workload per day - switch to new field names
timeline_events - there was a conflict with the `new_value` being sent from the service and the same `new value` being used in the field_uopdates table creation. I have got around this by using an alias on the `new_value` being sent from the service, it is now new_event_value. I'll check with Steven in the morning that it was the right approach.