### PR TITLE
work_histories start_date is received in format YYYY-MM-DD the existi…

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1883,7 +1883,7 @@ dfeAnalyticsDataform({
                 },
                 {
                     keyName: "start_date",
-                    dataType: "timestamp",
+                    dataType: "string",
                     description: "",
                 },
                 {


### PR DESCRIPTION
…ng type for this field was timestamp, resulting in Dataform filling with null values when dates received. This changes the type from timestamp to string.