### PR TITLE
Reverting dfe-analytics-dataform back to 1.8.0 from 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "2.6.7",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.1.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.8.0.tar.gz"
     }
 }


### PR DESCRIPTION
v1.8.1 was shared and i applied but it is still under approval, hence the change back.