### PR TITLE
dfe-analytics-dataform package upgreade to v1.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@dataform/core": "2.6.7",
-                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz"
+                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.2.tar.gz"
             }
         },
         "node_modules/@dataform/core": {
@@ -81,8 +81,8 @@
             "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
         },
         "node_modules/dfe-analytics-dataform": {
-            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz",
-            "integrity": "sha512-7UXwdiBPUSPYZAsLbyPnD8cys4qVoqSVCSIQLkIByl77hkS7jIPowHQKe6Tow/s3HC1FRng4/Xp3lpUhrvqR2w==",
+            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.2.tar.gz",
+            "integrity": "sha512-EhU06XF2gP4CREb1ifsLAv6uJFuA6nJH8+XSL/wgMuJ0VS/z+Us3CCMsXsfbnH/R4q0vCyLB1j0q9PG2tcKwMQ==",
             "dependencies": {
                 "@dataform/core": "2.9.0"
             }
@@ -239,8 +239,8 @@
             "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
         },
         "dfe-analytics-dataform": {
-            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz",
-            "integrity": "sha512-7UXwdiBPUSPYZAsLbyPnD8cys4qVoqSVCSIQLkIByl77hkS7jIPowHQKe6Tow/s3HC1FRng4/Xp3lpUhrvqR2w==",
+            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.2.tar.gz",
+            "integrity": "sha512-EhU06XF2gP4CREb1ifsLAv6uJFuA6nJH8+XSL/wgMuJ0VS/z+Us3CCMsXsfbnH/R4q0vCyLB1j0q9PG2tcKwMQ==",
             "requires": {
                 "@dataform/core": "2.9.0"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "2.6.7",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.2.tar.gz"
     }
 }


### PR DESCRIPTION
[dfe-analytics-dataform package upgreade to v1.9.2 ( bug fix)](https://github.com/DFE-Digital/apply-for-qualified-teacher-status-dataform/commit/11afbb9af97756f47be640cdf599399e42ade02b)