### PR TITLE
The fields consent_requested_at, consent_received_at and unsigned_con…

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1008,17 +1008,6 @@ dfeAnalyticsDataform({
                     dataType: "string",
                     description: "",
                 },
-
-                {
-                    keyName: "consent_received_at",
-                    dataType: "timestamp",
-                    description: "Applicant has returned the consent",
-                },
-                {
-                    keyName: "consent_requested_at",
-                    dataType: "timestamp",
-                    description: "Consent has been requested from the applicant",
-                },
                 {
                     keyName: "expired_at",
                     dataType: "timestamp",
@@ -1070,15 +1059,9 @@ dfeAnalyticsDataform({
                     keyName: "signed_consent_document_required",
                     dataType: "boolean",
                     description: "indicates whether a request for signed consent is required for qualification request - replaced by consent_method.",
-                    historic:true
+                    historic: true
                 },
-
-                {
-                    keyName: "unsigned_consent_document_downloaded",
-                    dataType: "boolean",
-                    description: "indicates whether an applicant has downloaded an unsigned consent document",
-                },
-                
+             
                 {
                     keyName: "verified_at",
                     dataType: "timestamp",


### PR DESCRIPTION
…sent_document_downloaded have been removed from the qualification requests model.