### PR TITLE
Mark part_of_university_degree as historic

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1111,6 +1111,7 @@ dfeAnalyticsDataform({
                     keyName: "part_of_university_degree",
                     dataType: "boolean",
                     description: "Teaching qualification part of university degree",
+                    historic: true,
                 },
                 {
                     keyName: "start_date",


### PR DESCRIPTION
This field has been replaced with the `teaching_qualification_part_of_degree` field on the application forms.