### PR TITLE
Remove document completed field

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -702,11 +702,6 @@ dfeAnalyticsDataform({
                     description: "",
                 },
                 {
-                    keyName: "completed",
-                    dataType: "boolean",
-                    description: "",
-                },
-                {
                     keyName: "document_type",
                     dataType: "string",
                     description: "",


### PR DESCRIPTION
This field has been removed from the live service as it’s no longer being used.