### PR TITLE
Add qualification_id to timeline events

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1863,6 +1863,11 @@ dfeAnalyticsDataform({
                     description: "",
                 },
                 {
+                    keyName: "qualification_id",
+                    dataType: "string",
+                    description: "Reference to the associated qualification for this timeline event, if there is one.",
+                },
+                {
                     keyName: "requestable_id",
                     dataType: "string",
                     description: "",


### PR DESCRIPTION
This adds a new field to the timeline events which was added in https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2172.