### PR TITLE
Add assessed_at to assessment sections

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -449,6 +449,11 @@ dfeAnalyticsDataform({
                     dataType: "boolean",
                     description: "f true, preliminary section to be assessed. If false, non preliminary section assessed",
                 },
+                {
+                    keyName: "assessed_at",
+                    dataType: "timestamp",
+                    description: "When the section was last assessed",
+                },
             ],
         },
         {


### PR DESCRIPTION
This adds a new field which will be used to capture when the assessment sections are assessed: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2177