### PR TITLE
Remove azure_ad_uid

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1316,11 +1316,6 @@ dfeAnalyticsDataform({
                     description: "",
                 },
                 {
-                    keyName: "azure_ad_uid",
-                    dataType: "string",
-                    description: "",
-                },
-                {
                     keyName: "change_email_permission",
                     dataType: "boolean",
                     description: "Whether the user has permission to change the application email address.",


### PR DESCRIPTION
This will no longer be streamed to BigQuery, and it's not useful to perform analytics on anyway so we can safely remove it.