### PR TITLE
Adding passport_country_of_issue_code to application_forms

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -180,6 +180,12 @@ dfeAnalyticsDataform({
                     historic: true,
                 },
                 {
+                    keyName: "passport_country_of_issue_code",
+                    dataType: "string",
+                    description: "Country of issue of passport provided by applicant",
+                    hidden: true,
+                },
+                {
                     keyName: "passport_document_status",
                     dataType: "string",
                     description: "passport document provided status",


### PR DESCRIPTION
As part of work done for [introducing the Country of issue to passport upload](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2644), the new passport_country_of_issue_code is now added to the application_forms table