### PR TITLE
AQTS 834 add manage staff permissions column to staff model

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1491,6 +1491,11 @@ dfeAnalyticsDataform({
                     description: "",
                 },
                 {
+                    keyName: "manage_staff_permission",
+                    dataType: "boolean",
+                    description: "",
+                },
+                {
                     keyName: "unconfirmed_email",
                     dataType: "string",
                     description: "",


### PR DESCRIPTION
This pr updates the schema for dataform as we've added a new column to the staff model https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2677