### PR TITLE
Adding eligible_work_experience_in_england to eligibility_checks table

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -736,6 +736,11 @@ dfeAnalyticsDataform({
                     dataType: "string",
                     description: "",
                 },
+                {
+                    keyName: "eligible_work_experience_in_england",
+                    dataType: "boolean",
+                    description: "Whether user has 'valid educational setting in England within the last 12 months?' during eligibility checker for prioritisation",
+                },
             ],
         },
         {


### PR DESCRIPTION
This introduces the new column based on work delivered here: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2773