### PR TITLE
Remove application_forms_suitability_records table as it has been added to blocklist

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -410,22 +410,6 @@ dfeAnalyticsDataform({
             ],
         },
         {
-            entityTableName: "application_forms_suitability_records",
-            description: "Table documenting status per assessment section",
-            keys: [
-                {
-                    keyName: "application_form_id",
-                    dataType: "string",
-                    description: "",
-                },
-                {
-                    keyName: "suitability_record_id",
-                    dataType: "string",
-                    description: "",
-                },
-            ],
-        },
-        {
             entityTableName: "assessment_sections",
             description: "Table documenting status per assessment section",
             keys: [


### PR DESCRIPTION
We are moving application_forms_suitability_records as this table doesn't seem to be accurate and used at all in analytics.